### PR TITLE
Fix subworkflow parameter description lookup

### DIFF
--- a/bin/generate-subworkflow-import
+++ b/bin/generate-subworkflow-import
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -eu
+(
+# go to the root directory of the project
+pushd "$(dirname $0)/.." > /dev/null
+
+# get the project's pipfile
+PIPFILE="$(readlink -f Pipfile)"
+
+# export PROJECT_ROOT for the project's .env (as "pwd" in .env doesn't work)
+export PROJECT_ROOT="$(pwd)"
+
+# go back to the calling directory
+popd > /dev/null
+
+# call pipenv + script
+PIPENV_PIPFILE=$PIPFILE pipenv --bare run python "$(dirname $0)/../scripts/subworkflow_preprocess.py" $@
+)

--- a/gsi_wdl_tools/workflow_info.py
+++ b/gsi_wdl_tools/workflow_info.py
@@ -95,11 +95,10 @@ class WorkflowInfo:
         # get parameter_metas from imported subworkflows
         for imp in doc.imports:
             import_parameter_meta = imp.doc.workflow.parameter_meta
-            param_descriptions.update({imp.namespace + "." + k: v for k, v in import_parameter_meta.items()})
+            param_descriptions.update({imp.doc.workflow.name + "." + k: v for k, v in import_parameter_meta.items()})
             # if imports contain task-level available_inputs, add the params for those
             for task in imp.doc.tasks:
-                param_descriptions.update(
-                    {imp.namespace + "." + task.name + "." + k: v for k, v in task.parameter_meta.items()})
+                param_descriptions.update({imp.doc.workflow.name + "." + task.name + "." + k: v for k, v in task.parameter_meta.items()})
 
         required_params = []
         optional_params = []


### PR DESCRIPTION
The subworkflow import alias is no longer used as the prefix for the workflow available_inputs (this behaviour matches womtools inputs).